### PR TITLE
Setting ulimit on arangodb container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
       ARANGO_ROOT_PASSWORD: M1qLriWYtac2KQgRIf15xDenrwjqxfpa
     volumes:
       - arangodb:/var/lib/arangodb3
+    ulimits:
+      nofile:
+        hard: 8192
+        soft: 8192
 
   emitter:
     image: emitter/server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       - arangodb:/var/lib/arangodb3
     ulimits:
       nofile:
-        hard: 8192
-        soft: 8192
+        hard: 1048576
+        soft: 1048576
 
   emitter:
     image: emitter/server


### PR DESCRIPTION
Fixes issue #1 by setting the ulimit for the arangodb container to the [required minimum](https://www.arangodb.com/docs/stable/release-notes-upgrading-changes38.html#file-descriptors) of 8192. 